### PR TITLE
Fix for toApiErrorObject to properly map extension

### DIFF
--- a/src/lib/errors/index.js
+++ b/src/lib/errors/index.js
@@ -153,7 +153,7 @@ class MojaloopFSPIOPError extends Error {
             }
         };
 
-        if(this.extensionList) {
+        if(this.extensions) {
             e.errorInformation.extensionList = this.extensions;
         }
 


### PR DESCRIPTION
- Fix for toApiErrorObject to properly map extension - it was failing to map the extension as the toApiErrorObject method was always comparing against a none-existing member variable `extensionList`. <-- thanks to @ndonnan